### PR TITLE
Changes for v0.6.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.6.11
+- Fix pending subscription timeout behaviour
+
 v0.6.10
 - Fix thing re-creation handling when no agent assigned
 - Remove unused acksecs parameter from AmqpLink

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PKGDIR = path.abspath(path.dirname(__file__))
 with open(path.join(PKGDIR, 'README.md'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
-VERSION = '0.6.10'
+VERSION = '0.6.11'
 
 setup(
     name='py-IoticAgent',
@@ -48,7 +48,7 @@ setup(
     packages=find_packages('src', exclude=['tests']),
     package_dir={'': 'src'},
     install_requires=[
-        'py-ubjson >= 0.8.5',
+        'py-ubjson >= 0.14.0',
         'rdflib >= 4.2.1',
         'enum34 >= 1.1.6; python_version < "3.4"',
     ],

--- a/src/IoticAgent/Core/AmqpLink.py
+++ b/src/IoticAgent/Core/AmqpLink.py
@@ -223,7 +223,7 @@ class AmqpLink(object):  # pylint: disable=too-many-instance-attributes
         if ((version_info[0] == 2 and (version_info[1] >= 7 and version_info[2] >= 5)) or
                 (version_info[0] == 3 and version_info[1] >= 4)):
             logger.debug('SSL method for 2.7.5+ / 3.4+')
-            # pylint: disable=no-name-in-module
+            # pylint: disable=no-name-in-module,import-outside-toplevel
             from ssl import SSLContext, PROTOCOL_TLSv1_2, CERT_REQUIRED, OP_NO_COMPRESSION
             ctx = SSLContext(PROTOCOL_TLSv1_2)
             ctx.set_ciphers('HIGH:!SSLv3:!TLSv1:!aNULL:@STRENGTH')
@@ -236,14 +236,14 @@ class AmqpLink(object):  # pylint: disable=too-many-instance-attributes
                 ctx.check_hostname = False
             else:
                 # Verify public certifcates if sslca is None (default)
-                from ssl import Purpose  # pylint: disable=no-name-in-module
+                from ssl import Purpose  # pylint: disable=no-name-in-module,import-outside-toplevel
                 ctx.load_default_certs(purpose=Purpose.SERVER_AUTH)
                 ctx.verify_mode = CERT_REQUIRED
                 ctx.check_hostname = True
 
         elif version_info[0] == 3 and version_info[1] < 4:
             logger.debug('Using SSL method for 3.2+, < 3.4')
-            # pylint: disable=no-name-in-module
+            # pylint: disable=no-name-in-module,import-outside-toplevel
             from ssl import SSLContext, CERT_REQUIRED, PROTOCOL_SSLv23, OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_TLSv1
             ctx = SSLContext(PROTOCOL_SSLv23)
             ctx.options |= (OP_NO_SSLv2 | OP_NO_SSLv3 | OP_NO_TLSv1)

--- a/src/IoticAgent/Core/Client.py
+++ b/src/IoticAgent/Core/Client.py
@@ -1213,8 +1213,7 @@ class Client(object):  # pylint: disable=too-many-instance-attributes,too-many-p
                         self.__request_except(requestId, exc, set_and_forget=False)
                         # request will be retried (assuming timeout is not reached after delay)
                         continue
-                    else:
-                        self.__request_except(requestId, exc)
+                    self.__request_except(requestId, exc)
                 else:
                     # if not published, an exception will have been set on the request already
                     if published:

--- a/src/IoticAgent/Core/RequestEvent.py
+++ b/src/IoticAgent/Core/RequestEvent.py
@@ -121,4 +121,9 @@ class RequestEvent(object):  # pylint: disable=too-many-instance-attributes
                 # todo better way to raise errors on behalf of other Threads?
                 raise self.exception  # pylint: disable=raising-bad-type
             return True
+
+        # Won't have been called in case a) _set() hasn't be called and b) request didn't complete before wait (see
+        # _run_on_completion).
+        if self._complete_func:
+            self.__run_completion_func(self._complete_func, self.id_)
         return False

--- a/src/IoticAgent/Core/__init__.py
+++ b/src/IoticAgent/Core/__init__.py
@@ -22,7 +22,7 @@ RequestEvent._messages will contain the raw messages from the queue.
 
 from __future__ import unicode_literals
 
-__version__ = '0.6.10'
+__version__ = '0.6.11'
 
 from . import Const  # noqa
 

--- a/src/IoticAgent/Core/compat/__init__.py
+++ b/src/IoticAgent/Core/compat/__init__.py
@@ -183,7 +183,7 @@ def py_version_check():
 
 
 def ssl_version_check():
-    from ssl import OPENSSL_VERSION_INFO as sslv, OPENSSL_VERSION
+    from ssl import OPENSSL_VERSION_INFO as sslv, OPENSSL_VERSION  # pylint: disable=import-outside-toplevel
     if not (sslv[0] > 1 or
             (sslv[0] == 1 and sslv[1] > 0) or
             (sslv[0] == 1 and sslv[1] == 0 and sslv[2] > 0)):

--- a/src/IoticAgent/IOT/Client.py
+++ b/src/IoticAgent/IOT/Client.py
@@ -51,7 +51,7 @@ from .PointValueHelper import PointDataObjectHandler, RefreshException
 class Client(object):  # pylint: disable=too-many-public-methods, too-many-lines
 
     # Core version targeted by IOT client
-    __core_version = '0.6.10'
+    __core_version = '0.6.11'
 
     def __init__(self, config=None):
         """

--- a/src/IoticAgent/IOT/Thing.py
+++ b/src/IoticAgent/IOT/Thing.py
@@ -580,7 +580,6 @@ class Thing(Resource):  # pylint: disable=too-many-public-methods
         return req
 
     def __sub(self, foc, gpid, callback=None):
-        logger.info("__sub(foc=%s, gpid=\"%s\", callback=%s) [lid=%s]", foc_to_str(foc), gpid, callback, self.__lid)
         evt = self.__sub_async(foc, gpid, callback=callback)
         self._client._wait_and_except_if_failed(evt)
         try:

--- a/src/IoticAgent/IOT/__init__.py
+++ b/src/IoticAgent/IOT/__init__.py
@@ -15,6 +15,6 @@
 helper objects for Thing, Point, etc.
 """
 
-__version__ = '0.6.10'
+__version__ = '0.6.11'
 
 from .Client import Client, SearchScope, DescribeScope  # NOQA


### PR DESCRIPTION
- Fix pending subscription timeout behaviour (https://github.com/Iotic-Labs/infra/pull/1013)
- Remove duplicated subscription logging statement
- Bump versions, increase minimum py-ubjson requirement

Notes:
- After this release has been made, the `docs` directory can be removed (due to all links pointing to readthedocs).
- Incorporate minor changes back into internal repo (infra)